### PR TITLE
feat: add CouchDB notification adapter

### DIFF
--- a/lib/notification/adapter/couchdb.js
+++ b/lib/notification/adapter/couchdb.js
@@ -1,0 +1,50 @@
+import { markdown2Html } from '../../services/markdown.js';
+import nano from 'nano';
+
+export const send = async ({ serviceName, newListings, notificationConfig, jobKey }) => {
+  const { url, database, username, password } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
+  const urlObject = new URL(url);
+  if (username != null && username !== '') {
+    urlObject.username = username;
+    urlObject.password = password || '';
+  }
+  const couch = nano(urlObject.toString());
+  try {
+    await couch.db.get(database);
+  } catch {
+    await couch.db.create(database);
+  }
+  const db = couch.db.use(database);
+  const docs = newListings.map((listing) => ({ ...listing, serviceName, jobKey }));
+  await db.bulk({ docs });
+  return Promise.resolve();
+};
+
+export const config = {
+  id: 'couchdb',
+  name: 'CouchDB',
+  description: 'This adapter stores listings in a CouchDB database.',
+  fields: {
+    url: {
+      type: 'text',
+      label: 'Server URL',
+      description: 'The CouchDB server URL (e.g. http://localhost:5984).',
+    },
+    database: {
+      type: 'text',
+      label: 'Database',
+      description: 'Database name where listings will be stored.',
+    },
+    username: {
+      type: 'text',
+      label: 'Username',
+      description: 'The username for authentication, if required.',
+    },
+    password: {
+      type: 'password',
+      label: 'Password',
+      description: 'The password for authentication, if required.',
+    },
+  },
+  readme: markdown2Html('lib/notification/adapter/couchdb.md'),
+};

--- a/lib/notification/adapter/couchdb.md
+++ b/lib/notification/adapter/couchdb.md
@@ -1,0 +1,9 @@
+### CouchDB Adapter
+
+This adapter stores search results in a CouchDB database. The adapter will create the database if it does not exist.
+
+Fields are:
+
+```
+['serviceName', 'jobKey', 'id', 'size', 'rooms', 'price', 'address', 'title', 'link', 'description']
+```

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lowdb": "6.0.1",
     "markdown": "^0.5.0",
     "mixpanel": "^0.18.1",
+    "nano": "10.1.4",
     "nanoid": "5.1.5",
     "node-fetch": "3.3.2",
     "node-mailjet": "6.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,6 +1976,15 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axios@^1.7.4:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
 axios@^1.8.1, axios@^1.8.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
@@ -3447,6 +3456,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
@@ -5270,6 +5290,15 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nano@10.1.4:
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/nano/-/nano-10.1.4.tgz#cb4cabd677733ddb81c88c1b8635101e2d84e926"
+  integrity sha512-bJOFIPLExIbF6mljnfExXX9Cub4W0puhDjVMp+qV40xl/DBvgKao7St4+6/GB6EoHZap7eFnrnx4mnp5KYgwJA==
+  dependencies:
+    axios "^1.7.4"
+    node-abort-controller "^3.1.1"
+    qs "^6.13.0"
+
 nanoid@5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.5.tgz#f7597f9d9054eb4da9548cdd53ca70f1790e87de"
@@ -5314,6 +5343,11 @@ node-abi@^3.3.0:
   integrity sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==
   dependencies:
     semver "^7.3.5"
+
+node-abort-controller@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
 node-domexception@^1.0.0:
   version "1.0.0"
@@ -5857,7 +5891,7 @@ puppeteer@^24.17.0:
     puppeteer-core "24.17.0"
     typed-query-selector "^2.12.0"
 
-qs@^6.14.0:
+qs@^6.13.0, qs@^6.14.0:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
   integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==


### PR DESCRIPTION
## Summary
- add CouchDB notification adapter to persist listings
- document CouchDB adapter
- include nano dependency for CouchDB access

## Testing
- `npx yarn@1.22.19 lint`
- `npx yarn@1.22.19 test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68af00372b30832ca0be1a030210e767