### PR TITLE
feat: add NocoDB notification adapter

### DIFF
--- a/lib/notification/adapter/nocodb.js
+++ b/lib/notification/adapter/nocodb.js
@@ -1,0 +1,50 @@
+import { markdown2Html } from '../../services/markdown.js';
+import fetch from 'node-fetch';
+
+export const send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
+  const { url, tableId, token } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
+  const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+  const endpoint = `${baseUrl}/api/v2/tables/${tableId}/rows`;
+
+  const promises = newListings.map((listing) =>
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'xc-token': token,
+      },
+      body: JSON.stringify({
+        ...listing,
+        serviceName,
+        jobKey,
+      }),
+    }),
+  );
+
+  return Promise.all(promises);
+};
+
+export const config = {
+  id: 'nocodb',
+  name: 'NocoDB',
+  description: 'This adapter stores listings in a NocoDB table using the v2 API.',
+  fields: {
+    url: {
+      type: 'text',
+      label: 'Base URL',
+      description: 'Base URL of your NocoDB instance (e.g. https://nocodb.example.com).',
+    },
+    tableId: {
+      type: 'text',
+      label: 'Table ID',
+      description: 'ID of the table where listings will be stored.',
+    },
+    token: {
+      type: 'text',
+      label: 'API Token',
+      description: 'NocoDB API token with access to the table.',
+    },
+  },
+  readme: markdown2Html('lib/notification/adapter/nocodb.md'),
+};
+

--- a/lib/notification/adapter/nocodb.md
+++ b/lib/notification/adapter/nocodb.md
@@ -1,0 +1,13 @@
+### NocoDB Adapter
+
+This adapter stores listings in a [NocoDB](https://nocodb.com/) table using the v2 REST API and an API token.
+
+1. Create a table in your NocoDB project.
+2. Generate an API token with access to that project.
+3. Find the table ID from the table's API info page.
+4. Configure the adapter in Fredy with:
+   - **Base URL** – URL of your NocoDB instance (e.g. `https://nocodb.example.com`)
+   - **Table ID** – ID of the table where rows should be inserted
+   - **API Token** – the token created in step 2
+
+The adapter will create a new row for each listing and adds the `serviceName` and `jobKey` to the stored data.


### PR DESCRIPTION
## Summary
- add NocoDB adapter to store listings via v2 API token
- document NocoDB configuration

## Testing
- `npm run lint`
- `npm test` *(fails: libatk-1.0.so.0 missing for puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bb3727c832c9372797777e11377