### PR TITLE
Fix NocoDB adapter to store listing fields

### DIFF
--- a/lib/notification/adapter/nocodb.js
+++ b/lib/notification/adapter/nocodb.js
@@ -1,25 +1,45 @@
 import { markdown2Html } from '../../services/markdown.js';
 import fetch from 'node-fetch';
 
+const fields = [
+  'serviceName',
+  'jobKey',
+  'id',
+  'size',
+  'rooms',
+  'price',
+  'address',
+  'title',
+  'link',
+  'description',
+];
+
 export const send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
   const { url, tableId, token } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
   const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
-  const endpoint = `${baseUrl}/api/v2/tables/${tableId}/rows`;
+  const endpoint = `${baseUrl}/api/v2/tables/${tableId}/records`;
 
-  const promises = newListings.map((listing) =>
-    fetch(endpoint, {
+  const promises = newListings.map((listing) => {
+    const record = {};
+    fields.forEach((field) => {
+      if (field === 'serviceName') {
+        record[field] = serviceName;
+      } else if (field === 'jobKey') {
+        record[field] = jobKey;
+      } else {
+        record[field] = listing[field];
+      }
+    });
+
+    return fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'xc-token': token,
       },
-      body: JSON.stringify({
-        ...listing,
-        serviceName,
-        jobKey,
-      }),
-    }),
-  );
+      body: JSON.stringify({ fields: record }),
+    });
+  });
 
   return Promise.all(promises);
 };

--- a/lib/notification/adapter/nocodb.md
+++ b/lib/notification/adapter/nocodb.md
@@ -2,7 +2,8 @@
 
 This adapter stores listings in a [NocoDB](https://nocodb.com/) table using the v2 REST API and an API token.
 
-1. Create a table in your NocoDB project.
+1. Create a table in your NocoDB project with the following columns:
+   `serviceName`, `jobKey`, `id`, `size`, `rooms`, `price`, `address`, `title`, `link` and `description`.
 2. Generate an API token with access to that project.
 3. Find the table ID from the table's API info page.
 4. Configure the adapter in Fredy with:
@@ -10,4 +11,4 @@ This adapter stores listings in a [NocoDB](https://nocodb.com/) table using the 
    - **Table ID** – ID of the table where rows should be inserted
    - **API Token** – the token created in step 2
 
-The adapter will create a new row for each listing and adds the `serviceName` and `jobKey` to the stored data.
+The adapter will create a new row for each listing and populates the columns above.


### PR DESCRIPTION
## Summary
- store specific listing fields when sending to NocoDB
- document required NocoDB table columns

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02510cc2c832cbe4fc97b030eff86