### PR TITLE
fix: send records directly to NocoDB

### DIFF
--- a/lib/notification/adapter/nocodb.js
+++ b/lib/notification/adapter/nocodb.js
@@ -37,7 +37,7 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey }) =
         'Content-Type': 'application/json',
         'xc-token': token,
       },
-      body: JSON.stringify({ fields: record }),
+      body: JSON.stringify(record),
     });
   });
 


### PR DESCRIPTION
## Summary
- send listing fields directly in NocoDB requests to prevent empty rows

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b15857c53c832cbe74f6eda3ce1da2